### PR TITLE
fix: Remover impressão de músicas sem partitura e ajuste no número das páginas

### DIFF
--- a/src/createSongBook.ts
+++ b/src/createSongBook.ts
@@ -226,6 +226,13 @@ const addSongPage = async (
   const initialPage = currentPage;
   const promises: Promise<void>[] = [];
 
+  // Guard: skip if the song has no part for this instrument
+  const partForInstrument = song.parts?.find((part) => part.instrument === instrument);
+  if (!partForInstrument) {
+    console.log(`Skipping ${song.title} for ${instrument}: no part available.`);
+    return [0, promises];
+  }
+
   if (backSheetPageNumber) {
     const fontSize = 9 * cm2pt;
     const titleSpacing = 6 * cm2pt;
@@ -304,13 +311,8 @@ const addSongPage = async (
       }
     ); // Estilo + Número
 
-  // TODO: Pensar em quando tiver mais de um arranjo
-  let svgUrl = "";
-  try {
-    svgUrl = song.parts.filter((part) => part.instrument == instrument)[0].svg;
-  } catch (error) {
-    console.log(`No part for ${instrument} in ${song.title}.`);
-  }
+  // Use the discovered part for the instrument safely
+  const svgUrl = partForInstrument.svg;
   promises.push(drawSvg(doc, `/collection/${svgUrl}`, currentPage));
 
   return [currentPage - initialPage, promises];

--- a/src/createSongBook.ts
+++ b/src/createSongBook.ts
@@ -452,7 +452,7 @@ const addIndexPage = (
       const songData = sections
         .flatMap(sec => sec.songs)
         .find(s => s.id === song.id);
-      const hasInstrument = songData?.hasInstrument || false;
+      const hasInstrument = (songData as any)?.hasInstrument || false;
       
       // Display song with consistent page number
       doc

--- a/src/tsx/PdfGenerator.tsx
+++ b/src/tsx/PdfGenerator.tsx
@@ -21,7 +21,7 @@ import {
   SongBookItem,
   SongBookScore,
 } from "../../types";
-import { createSongBook, CreateSongBookOptions } from "../createSongBook";
+import { createSongBook } from "../createSongBook";
 
 const instruments: Instrument[] = [
   "trompete",


### PR DESCRIPTION
## Resumo

- Só cria páginas para músicas que tem a partitura do instrumento em questão
- Não cria caderninhos quando não houver partituras (e gera alerta avisando)
- Implementa numeração de páginas consistente entre todos os caderninhos de instrumentos para facilitar a coordenação entre músicos
- Adiciona indicadores visuais no índice para músicas não disponíveis para instrumentos específicos
- Link para issue: Fixes #261 

## Mudanças

- **Numeração Consistente**: Criada lista mestra de músicas que garante que a mesma música tenha o mesmo número de página em todos os caderninhos de instrumentos
- **Indicadores Visuais**: Músicas não disponíveis para um instrumento específico aparecem no índice com texto riscado em cinza
- **Melhoria na Coordenação**: Músicos podem agora referenciar "página 5" e todos saberão exatamente qual música tocar, independente do instrumento (e da disponibilidade da música)

## Screenshots / Demos (se UI)

- Índice agora mostra todas as músicas com numeração consistente
- Músicas indisponíveis aparecem riscadas em cinza
- Páginas mantêm numeração consistente entre diferentes instrumentos

## Como testar

1. Acesse a aplicação em modo de desenvolvimento
2. Selecione algumas músicas para o caderninho (Ex: forasteiro do sopra que sara "arranjo william" tem tuba e não tem flauta)
3. Gere PDFs para diferentes instrumentos (ex: flauta e tuba)
4. Verifique que:
   - O índice mostra todas as músicas com numeração consistente
   - Músicas não disponíveis para o instrumento aparecem riscadas em cinza
   - As páginas das músicas têm números consistentes entre os instrumentos
   - Links clicáveis funcionam apenas para músicas disponíveis

## Checklist antes de publicar esta PR

- [x] Referencia a issue vinculada com `Fixes #<issue-id>` (fecha automaticamente na mesclagem)
- [x] Título da PR segue convenções: `feat:`, `fix:`, `song:`, ou `docs:`
- [x] PR pequena e focada
- [x] Passos de teste claros fornecidos (auto-testado)